### PR TITLE
Add check that to be chrome, it must not be edge

### DIFF
--- a/src/RenderInBrowser/browser-check.js
+++ b/src/RenderInBrowser/browser-check.js
@@ -45,7 +45,7 @@ export const isEdge = () => {
 }
 
 // Chrome 1+
-export const isChrome = () => !!window.chrome && !isOpera();
+export const isChrome = () => !!window.chrome && !isOpera() && !isEdge();
 
 export const allBrowsers = ['chrome', 'firefox', 'safari', 'opera', 'ie', 'edge', 'mobile'];
 


### PR DESCRIPTION
This PR prevents an edge browser from being detected as `chrome`. Because the logic in https://github.com/flexdinesh/react-render-in-browser/blob/709388db1683400f05cb312898aea84099824d7b/src/RenderInBrowser/RenderInBrowser.js#L25 selects for the first matched browser, chromium edge is still detected as chrome